### PR TITLE
Fix "Key not present" error

### DIFF
--- a/autoload/searchhi.vim
+++ b/autoload/searchhi.vim
@@ -268,7 +268,7 @@ endfunction
 
 function! searchhi#listen_cmdline_leave()
     if getcmdtype() == '/' || getcmdtype() == '?'
-        if v:event.abort
+        if has_key(v:event, 'abort') && v:event.abort
             let g:searchhi_search_abort_timer =
                 \ timer_start(
                     \ g:searchhi_search_abort_time,
@@ -332,7 +332,7 @@ function! searchhi#listen_leave()
 endfunction
 
 function! searchhi#await_cmdline_leave()
-    if (getcmdtype() == '/' || getcmdtype() == '?') && v:event.abort
+    if (getcmdtype() == '/' || getcmdtype() == '?') && has_key(v:event, 'abort') && v:event.abort
         call searchhi#clear_all()
     else
         call searchhi#listen_cmdline_leave()


### PR DESCRIPTION
## Why

Seemingly, `v:event` does not always have the `abort` key in it.

```
E716: Key not present in Dictionary: abort
```

## What

Check if the key exists in the dict.

