### PR TITLE
Silences search errors

### DIFF
--- a/autoload/searchhi.vim
+++ b/autoload/searchhi.vim
@@ -73,8 +73,8 @@ function! searchhi#update(...) range
         let search_query = query
     endif
 
-    let [end_line, end_column] = searchpos(search_query, 'bneW')
-    let [start_line, start_column] = searchpos(search_query, 'bcnW')
+    silent! let [end_line, end_column] = searchpos(search_query, 'bneW')
+    silent! let [start_line, start_column] = searchpos(search_query, 'bcnW')
 
     if start_line > end_line || start_column > end_column
         if !exists('g:searchhi_match') ||


### PR DESCRIPTION
When there is a search error, the error message keeps popping when moving the cursor. For instance, do the following:

1. Open a file in vim with searchhi enabled
1. Search for `asd\(`.
1. There is a `E54` error.
1. move the cursor using `k`

The user is interrupted a lot without value. This PR silences the repeated searches that searchhi performs. The error message will have already been shown to the user, so there is no real info being hidden by the user.