### PR TITLE
Fix "No such variable: g:searchhi_cmdline_leave_timer" issue in Neovim.

### DIFF
--- a/autoload/searchhi.vim
+++ b/autoload/searchhi.vim
@@ -253,7 +253,9 @@ function! searchhi#cmdline_leave_handler(timer)
         unlet g:searchhi_force_ignorecase
     endif
 
-    unlet g:searchhi_cmdline_leave_timer
+    if exists('g:searchhi_cmdline_leave_timer')
+        unlet g:searchhi_cmdline_leave_timer
+    endif
 endfunction
 
 function! searchhi#listen_cmdline_leave()


### PR DESCRIPTION
Most recently I've encountered the error "No such variable: g:searchhi_cmdline_leave_timer" in Neovim using vim-plug plugin manager. This might probably due to changes in Neovim timer. Hence I created this pull request to put in a guard to check whether "g:searchhi_cmdline_leave_timer" variable exists before doing the unlet. We probably should do the same for all other `unlet` statements, but for now this issue is causing lots of pain for me.