### PR TITLE
fix(autocommands): Fix Cannot define autocommands for ALL events error

### DIFF
--- a/autoload/searchhi.vim
+++ b/autoload/searchhi.vim
@@ -39,11 +39,15 @@ function! searchhi#listen(...) range
             autocmd CmdlineLeave * silent call searchhi#listen_cmdline_leave()
             autocmd CmdlineEnter * silent call searchhi#listen_cmdline_enter()
 
+            if g:searchhi_clear_all_autocmds
             execute 'autocmd! ' . g:searchhi_clear_all_autocmds .
                 \ ' * silent call searchhi#clear_all()'
+            endif
 
+            if g:searchhi_update_all_autocmds
             execute 'autocmd! ' . g:searchhi_update_all_autocmds .
                 \ ' * silent call searchhi#update_all()'
+            endif
         augroup END
     endif
 


### PR DESCRIPTION
Defining autocommands for all events is no longer allowed in vim 8.

See this patch: https://github.com/vim/vim/commit/9a046fd08bcae319d39a4dbde2be81decee19013

Solution here is to only add the custom autocommands if the searchhi config variables are defined.